### PR TITLE
Restructure documentation for LGM API

### DIFF
--- a/api-reference/endpoint/create.mdx
+++ b/api-reference/endpoint/create.mdx
@@ -1,4 +1,0 @@
----
-title: 'Create Plant'
-openapi: 'POST /plants'
----

--- a/api-reference/endpoint/delete.mdx
+++ b/api-reference/endpoint/delete.mdx
@@ -1,4 +1,0 @@
----
-title: 'Delete Plant'
-openapi: 'DELETE /plants/{id}'
----

--- a/api-reference/endpoint/get.mdx
+++ b/api-reference/endpoint/get.mdx
@@ -1,4 +1,0 @@
----
-title: 'Get Plants'
-openapi: 'GET /plants'
----

--- a/api-reference/endpoint/webhook.mdx
+++ b/api-reference/endpoint/webhook.mdx
@@ -1,4 +1,0 @@
----
-title: 'New Plant'
-openapi: 'WEBHOOK /plant/webhook'
----

--- a/api-reference/introduction.mdx
+++ b/api-reference/introduction.mdx
@@ -1,28 +1,17 @@
 ---
-title: 'Introduction'
-description: 'Example section for showcasing API endpoints'
+title: 'API Reference'
+description: 'Endpoints for the Livestock Gross Margin API'
 ---
 
+The LGM API is described by the OpenAPI specification included in this repository.
+
 <Note>
-  If you're not looking to build API reference documentation, you can delete
-  this section by removing the api-reference folder.
+  Each endpoint below is grouped according to tags defined in the specification.
 </Note>
-
-## Welcome
-
-There are two ways to build API documentation: [OpenAPI](https://mintlify.com/docs/api-playground/openapi/setup) and [MDX components](https://mintlify.com/docs/api-playground/mdx/configuration). For the starter kit, we are using the following OpenAPI specification.
-
-<Card
-  title="Plant Store Endpoints"
-  icon="leaf"
-  href="https://github.com/mintlify/starter/blob/main/api-reference/openapi.json"
->
-  View the OpenAPI specification file
-</Card>
 
 ## Authentication
 
-All API endpoints are authenticated using Bearer tokens and picked up from the specification file.
+All endpoints require a bearer token passed in the `Authorization` header.
 
 ```json
 "security": [

--- a/authentication.mdx
+++ b/authentication.mdx
@@ -1,0 +1,17 @@
+---
+title: "Authentication"
+description: "How to authenticate with the LGM API"
+---
+
+## API keys
+
+Requests to the Livestock Gross Margin API require a bearer token.
+
+1. Obtain your token from the AgencyRoot dashboard.
+2. Include the token in the `Authorization` header of each request.
+
+```http
+Authorization: Bearer YOUR_TOKEN
+```
+
+Tokens should be kept secret and rotated regularly.

--- a/docs.json
+++ b/docs.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://mintlify.com/docs.json",
   "theme": "mint",
-  "name": "Mint Starter Kit",
+  "name": "Livestock Gross Margin API",
   "colors": {
     "primary": "#16A34A",
     "light": "#07C983",
@@ -11,38 +11,13 @@
   "navigation": {
     "tabs": [
       {
-        "tab": "Guides",
+        "tab": "Documentation",
         "groups": [
           {
-            "group": "Getting started",
+            "group": "Overview",
             "pages": [
               "index",
-              "quickstart",
-              "development"
-            ]
-          },
-          {
-            "group": "Customization",
-            "pages": [
-              "essentials/settings",
-              "essentials/navigation"
-            ]
-          },
-          {
-            "group": "Writing content",
-            "pages": [
-              "essentials/markdown",
-              "essentials/code",
-              "essentials/images",
-              "essentials/reusable-snippets"
-            ]
-          },
-          {
-            "group": "AI tools",
-            "pages": [
-              "ai-tools/cursor",
-              "ai-tools/claude-code",
-              "ai-tools/windsurf"
+              "authentication"
             ]
           }
         ]
@@ -51,18 +26,9 @@
         "tab": "API reference",
         "groups": [
           {
-            "group": "API documentation",
+            "group": "LGM Endpoints",
             "pages": [
               "api-reference/introduction"
-            ]
-          },
-          {
-            "group": "Endpoint examples",
-            "pages": [
-              "api-reference/endpoint/get",
-              "api-reference/endpoint/create",
-              "api-reference/endpoint/delete",
-              "api-reference/endpoint/webhook"
             ]
           }
         ]
@@ -107,15 +73,15 @@
   },
   "contextual": {
     "options": [
-     "copy",
-     "view",
-     "chatgpt",
-     "claude",
-     "perplexity",
-     "mcp",
-     "cursor",
-     "vscode"
-   ]
+      "copy",
+      "view",
+      "chatgpt",
+      "claude",
+      "perplexity",
+      "mcp",
+      "cursor",
+      "vscode"
+    ]
   },
   "footer": {
     "socials": {

--- a/index.mdx
+++ b/index.mdx
@@ -1,97 +1,27 @@
 ---
-title: "Introduction"
-description: "Welcome to the new home for your documentation"
+title: "Livestock Gross Margin (LGM)"
+description: "Overview of the Livestock Gross Margin API"
 ---
 
-## Setting up
+The Livestock Gross Margin (LGM) API provides programmatic access to livestock quoting and policy data.
 
-Get your documentation site up and running in minutes.
+## Get started
 
-<Card
-  title="Start here"
-  icon="rocket"
-  href="/quickstart"
-  horizontal
->
-  Follow our three step quickstart guide.
-</Card>
-
-## Make it yours
-
-Design a docs site that looks great and empowers your users.
+Learn how to connect to the API and authenticate requests.
 
 <Columns cols={2}>
   <Card
-    title="Edit locally"
-    icon="pen-to-square"
-    href="/development"
+    title="Authentication"
+    icon="shield"
+    href="/authentication"
   >
-    Edit your docs locally and preview them in real time.
+    Generate a token and include it in each request.
   </Card>
   <Card
-    title="Customize your site"
-    icon="palette"
-    href="/essentials/settings"
-  >
-    Customize the design and colors of your site to match your brand.
-  </Card>
-    <Card
-    title="Set up navigation"
-    icon="map"
-    href="/essentials/navigation"
-  >
-    Organize your docs to help users find what they need and succeed with your product.
-  </Card>
-  <Card
-    title="API documentation"
+    title="API reference"
     icon="terminal"
     href="/api-reference/introduction"
   >
-    Auto-generate API documentation from OpenAPI specifications.
+    Review all available endpoints and examples.
   </Card>
 </Columns>
-
-## Create beautiful pages
-
-Everything you need to create world-class documentation.
-
-<Columns cols={2}>
-  <Card
-    title="Write with MDX"
-    icon="pen-fancy"
-    href="/essentials/markdown"
-  >
-    Use MDX to style your docs pages.
-  </Card>
-  <Card
-    title="Code samples"
-    icon="code"
-    href="/essentials/code"
-  >
-    Add sample code to demonstrate how to use your product.
-  </Card>
-  <Card
-    title="Images"
-    icon="image"
-    href="/essentials/images"
-  >
-    Display images and other media.
-  </Card>
-  <Card
-    title="Reusable snippets"
-    icon="recycle"
-    href="/essentials/reusable-snippets"
-  >
-    Write once and reuse across your docs.
-  </Card>
-</Columns>
-
-## Need inspiration?
-
-<Card
-  title="See complete examples"
-  icon="stars"
-  href="https://mintlify.com/customers"
->
-  Browse our showcase of exceptional documentation sites.
-</Card>


### PR DESCRIPTION
## Summary
- Replace starter docs layout with Livestock Gross Margin API structure
- Add Authentication guide and introduce LGM API on landing page
- Clean API reference and link to OpenAPI spec

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a835764ac083338782990c324bc9f4